### PR TITLE
Add flake for build and devshell.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ Make sure to have Go 1.23.1 installed.
 make local
 ```
 
+### Nix Flake
+
+```bash
+nix build
+```
+
+Binary will be at `./result/bin/newt`
+
+Development shell available with `nix develop`
+
 ## Licensing
 
 Newt is dual licensed under the AGPLv3 and the Fossorial Commercial license. For inquiries about commercial licensing, please contact us.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1742669843,
+        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,65 @@
+{
+  description = "newt - A tunneling client for Pangolin";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      pkgsFor = system: nixpkgs.legacyPackages.${system};
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+        in
+        {
+          default = self.packages.${system}.pangolin-newt;
+          pangolin-newt = pkgs.buildGoModule {
+            pname = "pangolin-newt";
+            version = "1.1.2";
+
+            src = ./.;
+
+            vendorHash = "sha256-sTtiBBkZ9cuhWnrn2VG20kv4nzNFfdzP5p+ewESCjyM=";
+
+            meta = with pkgs.lib; {
+              description = "A tunneling client for Pangolin";
+              homepage = "https://github.com/fosrl/newt";
+              license = licenses.gpl3;
+              maintainers = [ ];
+            };
+          };
+        }
+      );
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              go
+              gopls
+              gotools
+              go-outline
+              gopkgs
+              godef
+              golint
+            ];
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
Add nix flake for building and development shell.

Package named newt-pangolin to avoid conflicts with existing package name.

## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

For Nix/NixOS users, adds a flake.nix to allow building and creating a
development shell environment with some golang tools installed.

## How to test?

With Nix installed: `nix build`. The newt binary will be created in
`result/bin/`. To enter a development shell, `nix develop`. The tools listed in
the flake.nix will be available (go, golint, gopls, etc.).

When the version updates, update `version = "xxx";` and then `nix build`. It
will give you the updated `vendorHash` value to update in flake.nix.

